### PR TITLE
Allow manual dev deploys from any branch

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   deploy-dev:
     name: Deploy to dev
@@ -23,6 +24,7 @@ jobs:
 
   deploy-prod:
     name: Deploy to production
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: deploy-dev
     concurrency:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to Fly Deploy workflow
- Manual runs deploy to **dev only** — prod is gated behind `push` to `main`
- `workflow_dispatch` requires repo write access, so non-admins cannot trigger it

## How to use
Actions tab → Fly Deploy → Run workflow → select branch → Run

## Test plan
- [ ] Merge and trigger manual deploy from a feature branch — only dev deploys
- [ ] Push to main — both dev and prod deploy as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)