### PR TITLE
Implement some more quality of life features

### DIFF
--- a/src/convergence_games/apps/frontend/admin/services/_schedule_service.py
+++ b/src/convergence_games/apps/frontend/admin/services/_schedule_service.py
@@ -21,7 +21,8 @@ class ScheduleService:
             itertools.chain.from_iterable(
                 [game] * game.game_requirement.times_to_run
                 for game in event.games
-                if game.submission_status == SubmissionStatus.APPROVED
+                if game.submission_status != SubmissionStatus.CANCELLED
+                and game.submission_status != SubmissionStatus.REJECTED
             )
         )
 

--- a/src/convergence_games/apps/frontend/games/controllers/_detail.py
+++ b/src/convergence_games/apps/frontend/games/controllers/_detail.py
@@ -48,5 +48,6 @@ class GameController(Controller):
                 "user_game_played": user_game_context.user_game_played,
                 "scheduled_sessions": scheduled_sessions,
                 "has_d20": user_game_context.has_d20,
+                "user": request.user,
             },
         )

--- a/src/convergence_games/templates/components/Page.html.jinja
+++ b/src/convergence_games/templates/components/Page.html.jinja
@@ -8,6 +8,13 @@
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="manifest" href="/site.webmanifest" />
+        <meta property="og:site_name" content="Convergence 2026" />
+        <meta property="og:title" content="Convergence 2026" />
+        <meta property="og:description" content="The Waikato Role-Playing Guild's biggest event of the year - Convergence - returns this September 12th and 13th!" />
+        <meta property="og:image" content="https://nz.rs-cdn.com/images/nwstp-tbzqs/logo/cropped-67000/h624.png" />
+        <meta property="og:type" content="website" />
+        <meta property="og:image:width" content="1047" />
+        <meta property="og:image:height" content="624" />
         {# Libraries #}
         {% if SETTINGS.SENTRY_LOADER_SRC -%}
             <script>

--- a/src/convergence_games/templates/components/ScrollButton.jinja
+++ b/src/convergence_games/templates/components/ScrollButton.jinja
@@ -1,7 +1,7 @@
 {#def
 #}
 <div class="fixed right-0 bottom-0 z-10 p-4">
-    <button class="btn btn-circle btn-md btn-primary md:btn-lg" title="Scroll to Top" id="scroll-button">
+    <button class="btn hidden btn-circle btn-md btn-primary md:btn-lg" title="Scroll to Top" id="scroll-button">
         <span class="icon-[mdi--arrow-top]"></span>
     </button>
 </div>

--- a/src/convergence_games/templates/components/ScrollButton.jinja
+++ b/src/convergence_games/templates/components/ScrollButton.jinja
@@ -1,0 +1,10 @@
+{#def
+#}
+<div class="fixed right-0 bottom-0 z-10 p-4">
+    <button class="btn btn-circle btn-md btn-primary md:btn-lg" title="Scroll to Top" id="scroll-button">
+        <span class="icon-[mdi--arrow-top]"></span>
+    </button>
+</div>
+<script>
+    convergence.scroll_button("scroll-button");
+</script>

--- a/src/convergence_games/templates/index.ts
+++ b/src/convergence_games/templates/index.ts
@@ -1,4 +1,5 @@
 import event_manage_allocation from "./pages/event_manage_allocation";
 import event_manage_schedule from "./pages/event_manage_schedule";
+import scroll_button from "./pages/scroll_button";
 
-export { event_manage_allocation, event_manage_schedule };
+export { event_manage_allocation, event_manage_schedule, scroll_button };

--- a/src/convergence_games/templates/pages/event_games.html.jinja
+++ b/src/convergence_games/templates/pages/event_games.html.jinja
@@ -134,6 +134,7 @@
                     </form>
                 </div>
             </div>
+            <ScrollButton />
         </PageContainer>
     {% endblock %}
 </Page>

--- a/src/convergence_games/templates/pages/event_manage_players.html.jinja
+++ b/src/convergence_games/templates/pages/event_manage_players.html.jinja
@@ -21,6 +21,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <ScrollButton />
         </PageContainer>
     {% endblock %}
 </Page>

--- a/src/convergence_games/templates/pages/event_manage_submissions.html.jinja
+++ b/src/convergence_games/templates/pages/event_manage_submissions.html.jinja
@@ -46,6 +46,8 @@
                     </tr>
                 </tbody>
             </table>
+            {# TODO: The button breaks on table sort due to the HTMX partial reload #}
+            <ScrollButton />
         </PageContainer>
     {% endblock %}
 </Page>

--- a/src/convergence_games/templates/pages/event_session_planner.html.jinja
+++ b/src/convergence_games/templates/pages/event_session_planner.html.jinja
@@ -123,6 +123,7 @@
                     </div>
                 </div>
             {% endblock %}
+            <ScrollButton />
         </PageContainer>
     {% endblock content %}
 </Page>

--- a/src/convergence_games/templates/pages/game.html.jinja
+++ b/src/convergence_games/templates/pages/game.html.jinja
@@ -4,7 +4,15 @@
         <PageContainer>
             {# Header content #}
             <h1 class="text-3xl">{{ game.name }}</h1>
-            <div class="italic">{{ game.tagline }}</div>
+            <div class="flex flex-row justify-between">
+                <span class="italic">{{ game.tagline }}</span>
+                <a
+                    href="/game/{{ swim(game) }}/edit"
+                    class="{{ '' if user is not none and user | has_permission('game', (game.event, game), 'update') else 'hidden' }} btn btn-sm btn-neutral"
+                >
+                    Edit
+                </a>
+            </div>
             <div class="card rounded-box border border-base-300 bg-base-200">
                 <div class="card-body">
                     <h2 class="card-title">{{ game.system.name }} | Run by {{ game.gamemaster.full_name }}</h2>
@@ -158,7 +166,7 @@
                             {% if game.event.is_editing_open() %}
                                 <a href="/game/{{ swim(game) }}/edit" class="btn btn-primary">Edit</a>
                             {% else %}
-                                <button class="btn btn-primary btn-disabled" disabled>Editing closed</button>
+                                <button class="btn-disabled btn btn-primary" disabled>Editing closed</button>
                             {% endif %}
                         </div>
                     </div>

--- a/src/convergence_games/templates/pages/scroll_button.ts
+++ b/src/convergence_games/templates/pages/scroll_button.ts
@@ -5,6 +5,21 @@ const scroll_button = (element_id: string) => {
             console.error(`Could not find ${element_id} element`);
             return;
         }
+        // Create an observer that watches the nav element. When it scrolls
+        // out of the viewport (by more than 200px), we unhide the scroll to
+        // top button.
+        const observer = new IntersectionObserver((entries: IntersectionObserverEntry[]) => {
+            entries.forEach((entry: IntersectionObserverEntry) => {
+                if (entry.isIntersecting) {
+                    button.classList.add("hidden");
+                } else {
+                    button.classList.remove("hidden");
+                }
+            });
+        }, {
+            rootMargin: "200px"
+        });
+        observer.observe(document.getElementsByTagName("nav")[0]);
 
         button.addEventListener('click', () => {
             document.documentElement.scrollTo({

--- a/src/convergence_games/templates/pages/scroll_button.ts
+++ b/src/convergence_games/templates/pages/scroll_button.ts
@@ -1,0 +1,18 @@
+const scroll_button = (element_id: string) => {
+    document.addEventListener('DOMContentLoaded', (_: Event) => {
+        const button = document.getElementById(element_id);
+        if (!button) {
+            console.error(`Could not find ${element_id} element`);
+            return;
+        }
+
+        button.addEventListener('click', () => {
+            document.documentElement.scrollTo({
+                top: 0,
+                behavior: "smooth",
+            });
+        });
+    });
+}
+
+export default scroll_button;


### PR DESCRIPTION
Add in a few nice to have features:

- Edit button on game details page, if the user has edit permissions on the current game
- Open Graph metadata on the index page to avoid a sponsor logo showing when sharing on socials
- Partly revert change in 64c60db to show any games in the scheduler that are not cancelled nor rejected
- On long pages (such as the full games list and scheduler) add a floating action button that will scroll to the top of the page, which is automatically hidden when the viewport is near the top of the page